### PR TITLE
feat(vuex): create separeted module and share it

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,7 @@
 import Vue from "vue";
 
 import Vuex from "vuex";
+import userModuleFromRoot from './userModuleFromRoot'
 Vue.use(Vuex);
 
 const cartModule = {
@@ -29,29 +30,10 @@ const cartModule = {
   },
 };
 
-const userModule = {
-  namespaced: true,
-  state: {
-    user: null,
-  },
-  mutations: {
-    SET_USER(state, user) {
-      state.user = user;
-    },
-  },
-  actions: {
-    setUser(context, user) {
-      context.commit("SET_USER", user);
-    },
-  },
-  getters: {
-    user: (state) => state.user,
-  },
-};
 const store = new Vuex.Store({
   modules: {
     cart: cartModule,
-    user: userModule,
+    user: userModuleFromRoot,
   },
 });
 

--- a/src/userModuleFromRoot.js
+++ b/src/userModuleFromRoot.js
@@ -1,0 +1,22 @@
+export const userModule = {
+  namespaced: true,
+  state: {
+    user: null,
+  },
+  mutations: {
+    SET_USER(state, user) {
+      state.user = user;
+    },
+  },
+  actions: {
+    setUser(context, user) {
+      context.commit("SET_USER", user);
+    },
+  },
+  getters: {
+    user: (state) => {
+      return state.user;
+    },
+  },
+};
+

--- a/src/userModuleFromRoot.js
+++ b/src/userModuleFromRoot.js
@@ -1,4 +1,4 @@
-export const userModule = {
+export default {
   namespaced: true,
   state: {
     user: null,

--- a/vue.config.js
+++ b/vue.config.js
@@ -11,6 +11,7 @@ module.exports = {
         name: "root",
         filename: "remoteEntry.js",
         exposes: {
+          "./userModuleFromRoot": "./src/userModuleFromRoot",
           "./store": "./src/store",
         },
         remotes: {


### PR DESCRIPTION
I've created a separate module to expose it and use the namespace approach as @schirrel thought. 

The idea here is to make the root/host/shelf responsible to share global modules for the mfes.

Other PRs (into other MFEs:
https://github.com/mfe-module-federation-vue/cart/pull/1
https://github.com/mfe-module-federation-vue/profile/pull/1